### PR TITLE
OAuth Credentials migration

### DIFF
--- a/src/Keboola/ConfigMigrationTool/Application.php
+++ b/src/Keboola/ConfigMigrationTool/Application.php
@@ -9,6 +9,7 @@ use Keboola\ConfigMigrationTool\Exception\UserException;
 use Keboola\ConfigMigrationTool\Migration\GenericCopyMigration;
 use Keboola\ConfigMigrationTool\Migration\MigrationInterface;
 use Keboola\ConfigMigrationTool\Migration\DockerAppMigration;
+use Keboola\ConfigMigrationTool\Migration\OAuthMigration;
 use Monolog\Logger;
 use Symfony\Component\Serializer\Encoder\JsonDecode;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -65,6 +66,8 @@ class Application
             return $this->getLegacyMigration($config['parameters']['component']);
         } elseif (isset($config['parameters']['origin']) && isset($config['parameters']['destination'])) {
             return $this->getDockerAppMigration($config['parameters']['origin'], $config['parameters']['destination']);
+        } elseif (isset($config['parameters']['oauth'])) {
+            return $this->getOauthMigration($config['parameters']['oauth']);
         }
         throw new UserException("Missing parameters 'origin' and 'destination' or 'component'");
     }
@@ -85,6 +88,11 @@ class Application
             }
         }
         return $migration->setOriginComponentId($origin)->setDestinationComponentId($destination);
+    }
+
+    private function getOauthMigration(array $oauthConfig) : MigrationInterface
+    {
+        return new OAuthMigration($oauthConfig, $this->logger);
     }
 
     private function getLegacyMigration(string $component) : MigrationInterface

--- a/src/Keboola/ConfigMigrationTool/Migration/OAuthMigration.php
+++ b/src/Keboola/ConfigMigrationTool/Migration/OAuthMigration.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ConfigMigrationTool\Migration;
+
+use Keboola\ConfigMigrationTool\Service\OAuthService;
+use Keboola\ConfigMigrationTool\Service\OAuthV3Service;
+use Keboola\ConfigMigrationTool\Service\OrchestratorService;
+use Keboola\ConfigMigrationTool\Service\StorageApiService;
+use Monolog\Logger;
+
+class OAuthMigration extends DockerAppMigration
+{
+    /** @var array */
+    private $config;
+
+    /** @var OAuthService */
+    private $oauthService;
+
+    /** @var OAuthV3Service */
+    private $oauthV3Service;
+
+    public function __construct(array $config, Logger $logger)
+    {
+        parent::__construct($logger);
+        $this->config = $config;
+
+        $oauthV2Url = $this->storageApiService->getServiceUrl('syrup') . '/oauth-v2/';
+        $oauthV3Url = getenv('OAUTH_API_URL') ?: $this->storageApiService->getServiceUrl(StorageApiService::OAUTH_SERVICE);
+
+        $this->oauthService = new OAuthService($oauthV2Url);
+        $this->oauthV3Service = new OAuthV3Service($oauthV3Url);
+    }
+
+    public function execute(): array
+    {
+        $componentId = $this->config['componentId'];
+        $configurationId = $this->config['id'];
+
+        // load configuration from SAPI
+        $componentConfigurationJson = $this->storageApiService->getConfiguration($componentId, $configurationId);
+        $componentConfiguration = $this->buildConfigurationObject($componentId, $componentConfigurationJson);
+
+        // get Credentials from old OAuth Bundle
+        $credentials = $this->oauthService->getCredentialsRaw($componentId, $configurationId);
+
+        // add Credentials to new OAuth API
+        $newCredentials = $this->getNewCredentialsFromOld($credentials);
+        $response = $this->oauthV3Service->createCredentials($componentId, $newCredentials);
+
+        // save configuration with version set to 3
+        $this->saveConfigurationOptions($componentConfiguration, [
+            'authorization' => [
+                'oauth_api' =>[
+                    'version' => 3,
+                ],
+            ],
+        ]);
+
+        return $response;
+    }
+
+    public function status() : array
+    {
+        $sapiService = new StorageApiService();
+        $orchestratorService = new OrchestratorService();
+
+        $configurations = $sapiService->getConfigurations($this->originComponentId);
+        return [
+            'configurations' => array_map(
+                function ($item) {
+                    return [
+                        'configId' => $item['id'],
+                        'configName' => $item['name'],
+                        'componentId' => $this->originComponentId,
+                        'status' => isset($item['configuration']['migrationStatus'])
+                            ? $item['configuration']['migrationStatus'] : 'n/a',
+                    ];
+                },
+                $configurations
+            ),
+            'orchestrations' => $orchestratorService->getOrchestrations($this->originComponentId, $this->destinationComponentId),
+        ];
+    }
+
+    private function getNewCredentialsFromOld(\stdClass $credentials) : array
+    {
+        $newCredentials = [
+            'id' => $credentials->id,
+            'authorizedFor' => $credentials->authorized_for,
+            'data' => $credentials->data,
+        ];
+
+        if (!empty($credentials->app_key)) {
+            $newCredentials['appKey'] = $credentials->app_key;
+        }
+
+        if (!empty($credentials->app_secret_docker)) {
+            $newCredentials['appSecretDocker'] = $credentials->app_secret_docker;
+        }
+
+        if (!empty($credentials->auth_url)) {
+            $newCredentials['authUrl'] = $credentials->auth_url;
+        }
+
+        return $newCredentials;
+    }
+}

--- a/src/Keboola/ConfigMigrationTool/Migration/OAuthMigration.php
+++ b/src/Keboola/ConfigMigrationTool/Migration/OAuthMigration.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Keboola\ConfigMigrationTool\Migration;
 
-use Keboola\ConfigMigrationTool\Service\OAuthService;
 use Keboola\ConfigMigrationTool\Service\OAuthV3Service;
 use Keboola\ConfigMigrationTool\Service\OrchestratorService;
 use Keboola\ConfigMigrationTool\Service\StorageApiService;
+use Keboola\ConfigMigrationTool\Test\OAuthV2Service;
 use Monolog\Logger;
 
 class OAuthMigration extends DockerAppMigration
@@ -15,7 +15,7 @@ class OAuthMigration extends DockerAppMigration
     /** @var array */
     private $config;
 
-    /** @var OAuthService */
+    /** @var OAuthV2Service */
     private $oauthService;
 
     /** @var OAuthV3Service */
@@ -29,7 +29,7 @@ class OAuthMigration extends DockerAppMigration
         $oauthV2Url = $this->storageApiService->getServiceUrl('syrup') . '/oauth-v2/';
         $oauthV3Url = getenv('OAUTH_API_URL') ?: $this->storageApiService->getServiceUrl(StorageApiService::OAUTH_SERVICE);
 
-        $this->oauthService = new OAuthService($oauthV2Url);
+        $this->oauthService = new OAuthV2Service($oauthV2Url);
         $this->oauthV3Service = new OAuthV3Service($oauthV3Url);
     }
 

--- a/src/Keboola/ConfigMigrationTool/Service/OAuthService.php
+++ b/src/Keboola/ConfigMigrationTool/Service/OAuthService.php
@@ -12,10 +12,10 @@ class OAuthService
     /** @var Client */
     private $client;
 
-    public function __construct(string $baseUrl = 'https://syrup.keboola.com/oauth-v2/')
+    public function __construct()
     {
         $this->client = new Client([
-            'base_uri' => $baseUrl,
+            'base_uri' => 'https://syrup.keboola.com/oauth-v2/',
             'headers' => [
                 'X-StorageApi-Token' => getenv('KBC_TOKEN'),
             ],
@@ -30,38 +30,17 @@ class OAuthService
         return \GuzzleHttp\json_decode($response->getBody()->getContents());
     }
 
-    public function getCredentialsRaw(string $componentId, string $id) : \stdClass
-    {
-        $response = $this->client->get(sprintf('credentials/%s/%s/raw', $componentId, $id));
-
-        return \GuzzleHttp\json_decode($response->getBody()->getContents());
-    }
-
     public function createCredentials(string $componentId, array $account) : \stdClass
     {
-        $body = [
-            "id" => $account['id'],
-            "authorizedFor" => empty($account['email']) ? $account['owner'] : $account['email'],
-            "data" => [
-                "access_token" => $account['accessToken'],
-                "refresh_token" => $account['refreshToken'],
-            ],
-        ];
-
-        if (!empty($account['appKey'])) {
-            $body['appKey'] = $account['appKey'];
-        }
-
-        if (!empty($account['appSecretDocker'])) {
-            $body['appSecretDocker'] = $account['appSecretDocker'];
-        }
-
-        if (!empty($account['authUrl'])) {
-            $body['authUrl'] = $account['authUrl'];
-        }
-
         $response = $this->client->post(sprintf('credentials/%s', $componentId), [
-            'body' => \GuzzleHttp\json_encode($body),
+            'body' => \GuzzleHttp\json_encode([
+                "id" => $account['id'],
+                "authorizedFor" => empty($account['email']) ? $account['owner'] : $account['email'],
+                "data" => [
+                    "access_token" => $account['accessToken'],
+                    "refresh_token" => $account['refreshToken'],
+                ],
+            ]),
         ]);
 
         return \GuzzleHttp\json_decode($response->getBody()->getContents());

--- a/src/Keboola/ConfigMigrationTool/Service/OAuthV3Service.php
+++ b/src/Keboola/ConfigMigrationTool/Service/OAuthV3Service.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ConfigMigrationTool\Service;
+
+use GuzzleHttp\Client;
+use Keboola\StorageApi\HandlerStack;
+use Psr\Http\Message\ResponseInterface;
+
+class OAuthV3Service
+{
+    /** @var Client */
+    private $client;
+
+    public function __construct(string $baseUrl = 'https://oauth.keboola.com/')
+    {
+        $this->client = new Client([
+            'base_uri' => $baseUrl,
+            'headers' => [
+                'X-StorageApi-Token' => getenv('KBC_TOKEN'),
+            ],
+            'handler' => HandlerStack::create(),
+        ]);
+    }
+
+    public function getCredentials(string $componentId, string $id) : array
+    {
+        $response = $this->client->get(sprintf('credentials/%s/%s', $componentId, $id));
+
+        return \GuzzleHttp\json_decode($response->getBody()->getContents(), true);
+    }
+
+    public function createCredentials(string $componentId, array $credentials) : array
+    {
+        $response = $this->client->post(sprintf('credentials/%s', $componentId), [
+            'body' => \GuzzleHttp\json_encode($credentials),
+        ]);
+
+        return \GuzzleHttp\json_decode($response->getBody()->getContents(), true);
+    }
+
+    public function deleteCredentials(string $componentId, string $name) : ResponseInterface
+    {
+        return $this->client->delete(sprintf('credentials/%s/%s', $componentId, $name));
+    }
+}

--- a/src/Keboola/ConfigMigrationTool/Service/OAuthV3Service.php
+++ b/src/Keboola/ConfigMigrationTool/Service/OAuthV3Service.php
@@ -13,7 +13,7 @@ class OAuthV3Service
     /** @var Client */
     private $client;
 
-    public function __construct(string $baseUrl = 'https://oauth.keboola.com/')
+    public function __construct(string $baseUrl)
     {
         $this->client = new Client([
             'base_uri' => $baseUrl,

--- a/src/Keboola/ConfigMigrationTool/Test/OAuthV2Service.php
+++ b/src/Keboola/ConfigMigrationTool/Test/OAuthV2Service.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ConfigMigrationTool\Test;
+
+use GuzzleHttp\Client;
+use Keboola\StorageApi\HandlerStack;
+
+class OAuthV2Service
+{
+    /** @var Client */
+    private $client;
+
+    public function __construct(string $baseUrl)
+    {
+        $this->client = new Client([
+            'base_uri' => $baseUrl,
+            'headers' => [
+                'X-StorageApi-Token' => getenv('KBC_TOKEN'),
+            ],
+            'handler' => HandlerStack::create(),
+        ]);
+    }
+    public function getCredentials(string $componentId, string $id) : \stdClass
+    {
+        $response = $this->client->get(sprintf('credentials/%s/%s', $componentId, $id));
+
+        return \GuzzleHttp\json_decode($response->getBody()->getContents());
+    }
+
+    public function getCredentialsRaw(string $componentId, string $id) : \stdClass
+    {
+        $response = $this->client->get(sprintf('credentials/%s/%s/raw', $componentId, $id));
+
+        return \GuzzleHttp\json_decode($response->getBody()->getContents());
+    }
+
+    public function createCredentials(string $componentId, array $account) : \stdClass
+    {
+        $body = [
+            "id" => $account['id'],
+            "authorizedFor" => empty($account['email']) ? $account['owner'] : $account['email'],
+            "data" => [
+                "access_token" => $account['accessToken'],
+                "refresh_token" => $account['refreshToken'],
+            ],
+        ];
+        if (!empty($account['appKey'])) {
+            $body['appKey'] = $account['appKey'];
+        }
+        if (!empty($account['appSecretDocker'])) {
+            $body['appSecretDocker'] = $account['appSecretDocker'];
+        }
+        if (!empty($account['authUrl'])) {
+            $body['authUrl'] = $account['authUrl'];
+        }
+        $response = $this->client->post(sprintf('credentials/%s', $componentId), [
+            'body' => \GuzzleHttp\json_encode($body),
+        ]);
+
+        return \GuzzleHttp\json_decode($response->getBody()->getContents());
+    }
+}

--- a/tests/Keboola/ConfigMigrationTool/Migrations/OAuthMigrationTest.php
+++ b/tests/Keboola/ConfigMigrationTool/Migrations/OAuthMigrationTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Keboola\ConfigMigrationTool\Test\Migrations;
 
 use Keboola\ConfigMigrationTool\Migration\OAuthMigration;
-use Keboola\ConfigMigrationTool\Service\OAuthService;
 use Keboola\ConfigMigrationTool\Service\OAuthV3Service;
+use Keboola\ConfigMigrationTool\Test\OAuthV2Service;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\Components;
 use Keboola\StorageApi\Options\Components\Configuration;
@@ -21,7 +21,7 @@ class OAuthMigrationTest extends TestCase
     /** @var Components */
     private $components;
 
-    /** @var OAuthService */
+    /** @var OAuthV2Service */
     private $oauthService;
 
     /** @var array */
@@ -40,8 +40,8 @@ class OAuthMigrationTest extends TestCase
     {
         $this->storageApiClient = new Client(['token' => getenv('KBC_TOKEN'), 'url' => getenv('KBC_URL')]);
         $this->components = new Components($this->storageApiClient);
-        $this->oauthService = new OAuthService();
-        $this->oauthV3Service = new OAuthV3Service();
+        $this->oauthService = new OAuthV2Service('https://syrup.keboola.com/oauth-v2/');
+        $this->oauthV3Service = new OAuthV3Service('https://oauth.keboola.com/');
 
         $this->configurations[] = $this->createTestConfiguration($this->componentId);
         $this->configurations[] = $this->createTestConfiguration($this->componentId);

--- a/tests/Keboola/ConfigMigrationTool/Migrations/OAuthMigrationTest.php
+++ b/tests/Keboola/ConfigMigrationTool/Migrations/OAuthMigrationTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ConfigMigrationTool\Test\Migrations;
+
+use Keboola\ConfigMigrationTool\Migration\OAuthMigration;
+use Keboola\ConfigMigrationTool\Service\OAuthService;
+use Keboola\ConfigMigrationTool\Service\OAuthV3Service;
+use Keboola\StorageApi\Client;
+use Keboola\StorageApi\Components;
+use Keboola\StorageApi\Options\Components\Configuration;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+
+class OAuthMigrationTest extends TestCase
+{
+    /** @var Client */
+    private $storageApiClient;
+
+    /** @var Components */
+    private $components;
+
+    /** @var OAuthService */
+    private $oauthService;
+
+    /** @var array */
+    private $configurations = [];
+
+    /** @var array */
+    private $oauthCredentials = [];
+
+    /** @var string */
+    private $componentId = 'keboola.ex-google-drive';
+
+    /** @var OAuthV3Service */
+    private $oauthV3Service;
+
+    public function setUp() : void
+    {
+        $this->storageApiClient = new Client(['token' => getenv('KBC_TOKEN'), 'url' => getenv('KBC_URL')]);
+        $this->components = new Components($this->storageApiClient);
+        $this->oauthService = new OAuthService();
+        $this->oauthV3Service = new OAuthV3Service();
+
+        $this->configurations[] = $this->createTestConfiguration($this->componentId);
+        $this->configurations[] = $this->createTestConfiguration($this->componentId);
+        $this->configurations[] = $this->createTestConfiguration($this->componentId);
+        $this->configurations[] = $this->createTestConfiguration($this->componentId);
+
+        $this->oauthCredentials[] = $this->createOAuthConfig($this->configurations[0]);
+        $this->oauthCredentials[] = $this->createOAuthConfig($this->configurations[1]);
+        $this->oauthCredentials[] = $this->createOAuthConfigCustom($this->configurations[2]);
+        $this->oauthCredentials[] = $this->createOAuthConfigCustom($this->configurations[3]);
+    }
+
+    protected function createTestConfiguration(string $componentId) : string
+    {
+        $id = uniqid('migration-test');
+
+        $c = new Configuration();
+        $c->setComponentId($componentId);
+        $c->setConfigurationId($id);
+        $c->setName($id);
+        $c->setDescription('Migrate this account');
+        $c->setConfiguration(['authorization' => ['oauth_api' => ['id' => $id]]]);
+        $this->components->addConfiguration($c);
+
+        return $id;
+    }
+
+    protected function createOAuthConfig(string $configId) : \stdClass
+    {
+        return $this->oauthService->createCredentials($this->componentId, [
+            'id' => $configId,
+            'email' => 'test@keboola.com',
+            'accessToken' => '12345',
+            'refreshToken' => '567890',
+        ]);
+    }
+
+    protected function createOAuthConfigCustom(string $configId): \stdClass
+    {
+        return $this->oauthService->createCredentials($this->componentId, [
+            'id' => $configId,
+            'email' => 'test@keboola.com',
+            'accessToken' => '12345',
+            'refreshToken' => '567890',
+            'appKey' => 'appKey.12345.google.com',
+            'appSecretDocker' => 'KBC::ComponentSecure::tajmostvo',
+            'data' => [
+                'access_token' => 'qwertyuiop1234567890',
+            ],
+        ]);
+    }
+
+    protected function createMigrationConfig(string $configId) : array
+    {
+        return [
+            'componentId' => $this->componentId,
+            'id' => $configId,
+        ];
+    }
+
+    public function testExecute() : void
+    {
+        $responses = [];
+
+        foreach ($this->configurations as $index => $configurationId) {
+            $migration = new OAuthMigration(
+                $this->createMigrationConfig($configurationId),
+                new Logger(APP_NAME)
+            );
+            $response = $migration->execute();
+
+            $this->assertArrayHasKey('id', $response);
+            $this->assertArrayHasKey('authorizedFor', $response);
+            $this->assertArrayHasKey('creator', $response);
+            $this->assertArrayHasKey('created', $response);
+            $this->assertArrayHasKey('#data', $response);
+            $this->assertArrayHasKey('oauthVersion', $response);
+            $this->assertArrayHasKey('appKey', $response);
+            $this->assertArrayHasKey('#appSecret', $response);
+
+            $this->assertEquals('test@keboola.com', $response['authorizedFor']);
+            $this->assertEquals($configurationId, $response['id']);
+
+            $oldCredentials = $this->oauthCredentials[$index];
+            $this->assertEquals($oldCredentials->{'#data'}, $response['#data']);
+
+            if ($index > 1) {
+                $this->assertEquals('KBC::ComponentSecure::tajmostvo', $response['#appSecret']);
+            }
+
+            $responses[] = $response;
+        }
+
+        $this->assertNotEmpty($responses);
+
+        //cleanup
+        foreach ($responses as $res) {
+            $this->oauthV3Service->deleteCredentials($this->componentId, $res['id']);
+        }
+    }
+}

--- a/tests/Keboola/ConfigMigrationTool/Migrations/OAuthMigrationTest.php
+++ b/tests/Keboola/ConfigMigrationTool/Migrations/OAuthMigrationTest.php
@@ -106,6 +106,8 @@ class OAuthMigrationTest extends TestCase
     {
         $responses = [];
 
+        $this->assertCount(4, $this->configurations);
+
         foreach ($this->configurations as $index => $configurationId) {
             $migration = new OAuthMigration(
                 $this->createMigrationConfig($configurationId),


### PR DESCRIPTION
Vychadza z #28 

Backend pre migraciu OAuth Credentials

  - vezme nerozsifrovane credentials zo stareho OAuth Bundle (get credentials raw)

  - vlozi ich do noveho OAuth API. To je upravene tak, ze uz zasifrovane hodnoty nezasifruje znovu

Teraz je to spravene tak, ze to zalozi jeden job pre kazdu konfiguraciu, mozno by bolo lepsie zmigrovat vsetky (vybrane) konfiguracie v jednom jobe. Co myslite?