### PR TITLE
GoodData writer: fix valid dimensions migration

### DIFF
--- a/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoodDataWriterMigration.php
+++ b/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoodDataWriterMigration.php
@@ -158,7 +158,7 @@ class KeboolaGoodDataWriterMigration extends GenericCopyMigration
         unset($newConfig['configuration']['parameters']['addDatasetTitleToColumns']);
         if (isset($newConfig['configuration']['parameters']['dimensions'])) {
             foreach ($newConfig['configuration']['parameters']['dimensions'] as $dimensionId => $dim) {
-                if ($dim['template'] != 'keboola' && $dim['template'] != 'gooddata') {
+                if ($dim['template'] !== 'keboola' && $dim['template'] !== 'gooddata') {
                     $newConfig['configuration']['parameters']['dimensions'][$dimensionId]['templateId'] = $newConfig['configuration']['parameters']['dimensions'][$dimensionId]['customTemplate'];
                     $newConfig['configuration']['parameters']['dimensions'][$dimensionId]['template'] = 'custom';
                 }

--- a/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoodDataWriterMigration.php
+++ b/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoodDataWriterMigration.php
@@ -158,6 +158,11 @@ class KeboolaGoodDataWriterMigration extends GenericCopyMigration
         unset($newConfig['configuration']['parameters']['addDatasetTitleToColumns']);
         if (isset($newConfig['configuration']['parameters']['dimensions'])) {
             foreach ($newConfig['configuration']['parameters']['dimensions'] as $dimensionId => $dim) {
+                if ($dim['template'] != 'keboola' && $dim['template'] != 'gooddata') {
+                    $newConfig['configuration']['parameters']['dimensions'][$dimensionId]['templateId'] = $newConfig['configuration']['parameters']['dimensions'][$dimensionId]['customTemplate'];
+                    $newConfig['configuration']['parameters']['dimensions'][$dimensionId]['template'] = 'custom';
+                }
+                unset($newConfig['configuration']['parameters']['dimensions'][$dimensionId]['customTemplate']);
                 unset($newConfig['configuration']['parameters']['dimensions'][$dimensionId]['isExported']);
             }
         }

--- a/tests/Keboola/ConfigMigrationTool/Migrations/KeboolaGoodDataWriterMigrationTest.php
+++ b/tests/Keboola/ConfigMigrationTool/Migrations/KeboolaGoodDataWriterMigrationTest.php
@@ -65,6 +65,7 @@ class KeboolaGoodDataWriterMigrationTest extends TestCase
             ],
             'dimensions' => [
                 'd1' => [
+                    'template' => 'gooddata',
                     'title' => uniqid(),
                     'includeTime' => true,
                     'isExported' => true,
@@ -200,6 +201,7 @@ class KeboolaGoodDataWriterMigrationTest extends TestCase
             $result['configuration']['parameters']['project']['backendUrl']
         );
         $this->assertArrayNotHasKey('domain', $result['configuration']['parameters']);
+        $this->assertArrayNotHasKey('customTemplate', $result['configuration']['parameters']['dimensions']['d1']);
 
         $this->assertArrayHasKey('tables', $result['configuration']['parameters']);
         $this->assertCount(3, $result['configuration']['parameters']['tables']);


### PR DESCRIPTION
fixes #53 
related to https://github.com/keboola/internal/issues/60
- vzdy zmaze `customTemplate` v dimension objekte
- ak dimension template property neobsahuje gooddata ani keboola tak ulozi `template="custom"` a `templateId = <customTemplate>`