### PR TITLE
gooddata writer: dont migrate customTemplate of a date dimension

### DIFF
--- a/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoodDataWriterMigration.php
+++ b/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoodDataWriterMigration.php
@@ -159,6 +159,7 @@ class KeboolaGoodDataWriterMigration extends GenericCopyMigration
         if (isset($newConfig['configuration']['parameters']['dimensions'])) {
             foreach ($newConfig['configuration']['parameters']['dimensions'] as $dimensionId => $dim) {
                 unset($newConfig['configuration']['parameters']['dimensions'][$dimensionId]['isExported']);
+                unset($newConfig['configuration']['parameters']['dimensions'][$dimensionId]['customTemplate']);
             }
         }
         if (!empty($oldConfig['rows'])) {

--- a/tests/Keboola/ConfigMigrationTool/Migrations/KeboolaGoodDataWriterMigrationTest.php
+++ b/tests/Keboola/ConfigMigrationTool/Migrations/KeboolaGoodDataWriterMigrationTest.php
@@ -68,6 +68,7 @@ class KeboolaGoodDataWriterMigrationTest extends TestCase
                     'title' => uniqid(),
                     'includeTime' => true,
                     'isExported' => true,
+                    'customTemplate' => '',
                 ],
             ],
         ];
@@ -215,7 +216,10 @@ class KeboolaGoodDataWriterMigrationTest extends TestCase
             $result['configuration']['parameters']['project']['backendUrl']
         );
         $this->assertArrayNotHasKey('domain', $result['configuration']['parameters']);
-        
+
+        $this->assertArrayHasKey('d1', $result['configuration']['parameters']['dimensions']);
+        $this->assertArrayNotHasKey('customTemplate', $result['configuration']['parameters']['dimensions']['d1']);
+
         $this->assertArrayHasKey('tables', $result['configuration']['parameters']);
         $this->assertCount(3, $result['configuration']['parameters']['tables']);
         $this->assertArrayHasKey('columns', $result['configuration']['parameters']['tables']['t1']);


### PR DESCRIPTION
dosledkom ui bugu sa do configu dostane "neskodna" dimensions property `customTemplate` ktora ale sposobi ze zmigrovany konfig je nevalidny.
Viac infa v https://github.com/keboola/gooddata-writer-v3/issues/32#issuecomment-472347226