### PR TITLE
gooddata writer: set change description of old config update after migration

### DIFF
--- a/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoodDataWriterMigration.php
+++ b/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoodDataWriterMigration.php
@@ -91,6 +91,7 @@ class KeboolaGoodDataWriterMigration extends GenericCopyMigration
 
                     $createdConfigurations[] = $configuration;
                     $oldConfiguration = $this->buildConfigurationObject($this->originComponentId, $oldConfig);
+                    $oldConfiguration->setChangeDescription('migration status updated');
                     $this->saveConfigurationOptions($oldConfiguration, ['migrationStatus' => 'success']);
                 } catch (\Throwable $e) {
                     $oldConfiguration = $this->buildConfigurationObject($this->originComponentId, $oldConfig);


### PR DESCRIPTION
Po migracii sa do stareho configu uklada `migration: success` - tato uprava prida change description takemuto update konfigu s hlaskou `migration status updated`
vyplynulo z debaty https://github.com/keboola/kbc-ui/issues/2673#issuecomment-472394166