### PR TITLE
gooddata writer: don't migrate grain if it is an empty string

### DIFF
--- a/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoodDataWriterMigration.php
+++ b/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoodDataWriterMigration.php
@@ -183,6 +183,8 @@ class KeboolaGoodDataWriterMigration extends GenericCopyMigration
 
                 if (!empty($r['configuration']['grain'])) {
                     $r['configuration']['grain'] = explode(',', $r['configuration']['grain']);
+                } else {
+                    unset($r['configuration']['grain']);
                 }
 
                 unset($r['configuration']['export']);

--- a/tests/Keboola/ConfigMigrationTool/Migrations/KeboolaGoodDataWriterMigrationTest.php
+++ b/tests/Keboola/ConfigMigrationTool/Migrations/KeboolaGoodDataWriterMigrationTest.php
@@ -121,6 +121,7 @@ class KeboolaGoodDataWriterMigrationTest extends TestCase
         $tableConfiguration2 = [
             'title' => uniqid(),
             'export' => 1,
+            'grain' => '',
             'columns' => [
                 'ignoredColumn' => [
                     'type' => 'IGNORE',
@@ -230,6 +231,8 @@ class KeboolaGoodDataWriterMigrationTest extends TestCase
 
         $this->assertArrayHasKey('grain', $result['configuration']['parameters']['tables']['t1']);
         $this->assertEquals(['c1', 'c2', 'c3'], $result['configuration']['parameters']['tables']['t1']['grain']);
+
+        $this->assertArrayNotHasKey('grain', $result['configuration']['parameters']['tables']['t2']);
 
         $this->assertArrayHasKey('storage', $result['configuration']);
         $this->assertArrayHasKey('input', $result['configuration']['storage']);


### PR DESCRIPTION
Ak sa v starom gooddata writer ui nastavi fact grain a potom sa resetne tak sa ten resetnuty fact grain ulozi ako prazdny string, migracia takyto prazdny string len prekopiruje, potom pada load na nevalidnom konfigu pretoze v novom writery je grain ako pole. Tato uprava nezmigruje resp ignoruje grain ak je prazdny string 
vyplynulo z debaty
https://github.com/keboola/gooddata-writer-v3/issues/32#issuecomment-472461266