### PR TITLE
gooddata writer: always migrate orchestration task action to 'run'

### DIFF
--- a/src/Keboola/ConfigMigrationTool/Service/OrchestratorService.php
+++ b/src/Keboola/ConfigMigrationTool/Service/OrchestratorService.php
@@ -123,6 +123,10 @@ class OrchestratorService
                     $task['component'] = $newConfiguration->getComponentId();
                     $update = true;
                 }
+
+                if ($oldComponentId == 'gooddata-writer') {
+                    $task['action'] = 'run';
+                }
             }
         }
 


### PR DESCRIPTION
fixes #66 
tato uprava nastavi `action: "run"` kazdemu orchestracnemu task ktory sa migruje v pripade ze sa migruje gooddata writer. Dal som to takto natvrdo lebo je to zrejme posledna non docker komponenta ktora to ma takto specificke, teda vsetky kbc komponenty by mali mat action = run.