### PR TITLE
feat: optional encryption

### DIFF
--- a/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoodDataWriterMigration.php
+++ b/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoodDataWriterMigration.php
@@ -52,12 +52,13 @@ class KeboolaGoodDataWriterMigration extends GenericCopyMigration
 
     /**
      * @param callable|null $migrationHook Optional callback to adjust configuration object before saving
+     * @param bool|null $encryption
      * @return array
      * @throws ApplicationException
      * @throws UserException
      * @throws \GuzzleHttp\Exception\GuzzleException
      */
-    protected function doExecute(?callable $migrationHook = null): array
+    protected function doExecute(?callable $migrationHook = null, ?bool $encryption = parent::FORCE_ENCRYPTION): array
     {
         $pidsForExtractor = [];
         $createdConfigurations = [];


### PR DESCRIPTION
pro https://github.com/keboola/config-migration-tool/issues/69 jsem chtěl doplnit sekci `service_credentials`, ale přišlo mi blbý, že je prázdnej string hnedka zašifrovanej (implikuje mi to, že tam byla nějaká hodnota). tak jsem doplnil volitelný šifrování. není to blbost a nemá nechat empty string prostě zašifrovat?