### PR TITLE
fix: add empty service_account in google bigquery writer migration

### DIFF
--- a/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoogleBigQueryWriterMigration.php
+++ b/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoogleBigQueryWriterMigration.php
@@ -21,6 +21,18 @@ class KeboolaGoogleBigQueryWriterMigration extends GenericCopyMigration
         if (isset($configurationData["parameters"]["project"])) {
             unset($configurationData["parameters"]["project"]);
         }
+        $configurationData["parameters"]["service_account"] = [
+            "#private_key" => "",
+            "project_id" => "",
+            "token_uri" => "",
+            "client_email" => "",
+            "client_id" => "",
+            "auth_uri" => "",
+            "auth_provider_x509_cert_url" => "",
+            "private_key_id" => "",
+            "client_x509_cert_url" => "",
+            "type" => "",
+        ];
         $configuration->setConfiguration($configurationData);
         return $configuration;
     }

--- a/tests/Keboola/ConfigMigrationTool/Migrations/KeboolaGoogleBigQueryWriterMigrationFunctionalTest.php
+++ b/tests/Keboola/ConfigMigrationTool/Migrations/KeboolaGoogleBigQueryWriterMigrationFunctionalTest.php
@@ -128,11 +128,26 @@ class KeboolaGoogleBigQueryWriterMigrationFunctionalTest extends TestCase
         $this->assertEquals($configId, $configurations[0]['id']);
 
         $configuration = $components->getConfiguration(self::REPLACEMENT_COMPONENT_ID, $configurations[0]['id']);
+        $configurationData = $configuration['configuration'];
+        $this->assertStringContainsString('KBC::ProjectSecure::', $configurationData['parameters']['service_account']['#private_key']);
+        $configurationData['parameters']['service_account']['#private_key'] = '';
         $this->assertEquals([
             'parameters' => [
+                'service_account' => [
+                    '#private_key' => '',
+                    'project_id' => '',
+                    'token_uri' => '',
+                    'client_email' => '',
+                    'client_id' => '',
+                    'auth_uri' => '',
+                    'auth_provider_x509_cert_url' => '',
+                    'private_key_id' => '',
+                    'client_x509_cert_url' => '',
+                    'type' => '',
+                ],
                 'dataset' => 'travis_test',
             ],
-        ], $configuration['configuration']);
+        ], $configurationData);
 
         $this->assertCount(2, $configuration['rows']);
 

--- a/tests/Keboola/ConfigMigrationTool/Migrations/KeboolaGoogleBigQueryWriterMigrationTest.php
+++ b/tests/Keboola/ConfigMigrationTool/Migrations/KeboolaGoogleBigQueryWriterMigrationTest.php
@@ -34,6 +34,18 @@ class KeboolaGoogleBigQueryWriterMigrationTest extends TestCase
                 ],
             ],
             'parameters' => [
+                'service_account' => [
+                    '#private_key' => '',
+                    'project_id' => '',
+                    'token_uri' => '',
+                    'client_email' => '',
+                    'client_id' => '',
+                    'auth_uri' => '',
+                    'auth_provider_x509_cert_url' => '',
+                    'private_key_id' => '',
+                    'client_x509_cert_url' => '',
+                    'type' => '',
+                ],
                 'dataset' => 'travis_test',
             ],
         ], $result->getConfiguration());


### PR DESCRIPTION
fixes #69 