### PR TITLE
Encrypt passwords in new configurations at once

### DIFF
--- a/src/Keboola/ConfigMigrationTool/Migration/GenericCopyMigration.php
+++ b/src/Keboola/ConfigMigrationTool/Migration/GenericCopyMigration.php
@@ -32,14 +32,15 @@ class GenericCopyMigration extends DockerAppMigration
                 || $oldConfig['configuration']['migrationStatus'] != 'success') {
                 try {
                     $configuration = $this->buildConfigurationObject($this->destinationComponentId, $oldConfig);
-                    $this->storageApiService->createConfiguration($configuration);
                     if ($migrationHook) {
                         $configuration = $migrationHook($configuration);
                     }
                     $c = $configuration->getConfiguration();
                     unset($c['authorization']);
                     $configuration->setConfiguration($c);
-                    $this->storageApiService->encryptAndSaveConfiguration($configuration);
+
+                    $configuration->setConfiguration($this->storageApiService->encryptConfiguration($configuration));
+                    $this->storageApiService->createConfiguration($configuration);
 
                     if (!empty($oldConfig['rows'])) {
                         foreach ($oldConfig['rows'] as $r) {

--- a/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoodDataWriterMigration.php
+++ b/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoodDataWriterMigration.php
@@ -66,16 +66,15 @@ class KeboolaGoodDataWriterMigration extends GenericCopyMigration
                 || $oldConfig['configuration']['migrationStatus'] != 'success') {
                 try {
                     $newConfig = $this->transformConfiguration($oldConfig);
-                    $configuration = $this->buildConfigurationObject($this->destinationComponentId, $newConfig);
-
                     $this->checkGoodDataConfiguration($newConfig);
                     $this->addProjectToProvisioning($this->provisioning, $newConfig);
                     $this->addUsersToProvisioning($this->provisioning, $this->legacyWriter, $newConfig);
 
                     $pidsForExtractor[$newConfig['id']] = $newConfig['configuration']['parameters']['project']['pid'];
 
+                    $configuration = $this->buildConfigurationObject($this->destinationComponentId, $newConfig);
+                    $configuration->setConfiguration($this->storageApiService->encryptConfiguration($configuration));
                     $this->storageApiService->createConfiguration($configuration);
-                    $this->storageApiService->encryptAndSaveConfiguration($configuration);
 
                     $this->logger->info(sprintf(
                         "Configuration '%s' has been migrated",

--- a/tests/Keboola/ConfigMigrationTool/Migrations/KeboolaGoodDataWriterMigrationTest.php
+++ b/tests/Keboola/ConfigMigrationTool/Migrations/KeboolaGoodDataWriterMigrationTest.php
@@ -16,6 +16,7 @@ use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Components;
 use Keboola\StorageApi\Options\Components\Configuration;
 use Keboola\StorageApi\Options\Components\ConfigurationRow;
+use Keboola\StorageApi\Options\Components\ListComponentConfigurationsOptions;
 use Monolog\Logger;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -172,6 +173,14 @@ class KeboolaGoodDataWriterMigrationTest extends TestCase
 
         $this->storageApiClient = new Client(['token' => getenv('KBC_TOKEN'), 'url' => getenv('KBC_URL')]);
         $this->components = new Components($this->storageApiClient);
+
+        // Storage Cleanup
+        $oldConfigs = $this->components->listComponentConfigurations(
+            ((new ListComponentConfigurationsOptions())->setComponentId($this->originComponentId))
+        );
+        foreach ($oldConfigs as $oldConfig) {
+            $this->components->deleteConfiguration($this->originComponentId, $oldConfig['id']);
+        }
 
         $c = new Configuration();
         $c->setComponentId($this->originComponentId);
@@ -388,7 +397,6 @@ class KeboolaGoodDataWriterMigrationTest extends TestCase
     {
         $mock = $this->createMock(LegacyGoodDataWriterService::class);
         $mock->method('listUsers')->willReturn($listUsersResult);
-        $mock->expects($this->once())->method('listUsers');
         return $mock;
     }
 


### PR DESCRIPTION
Metoda `StorageApiService::encryptAndSaveConfiguration` funguje jen na update existující konfigurace, takže se tam vytvořila nová konfigurace s neenkrypovaným heslem a teprve potom se updatla. Jenže to neekryptovaný heslo bylo vidět v historii verzí.

(Plus cleanup Storage v testech a to `once()` omezení na mocku `listUsers()` starýho Writeru byla nějaká haluz, divím se že to doteď fungovalo ;o)