### PR TITLE
gooddata writer: don't migrate identifierTime to new config

### DIFF
--- a/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoodDataWriterMigration.php
+++ b/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoodDataWriterMigration.php
@@ -169,6 +169,10 @@ class KeboolaGoodDataWriterMigration extends GenericCopyMigration
                 $r['configuration']['columns'] = array_filter($r['configuration']['columns'], function ($column) {
                     return $column['type'] !== 'IGNORE' && $column['type'] !== 'ignore';
                 });
+                $r['configuration']['columns'] = array_map(function ($column) {
+                    unset($column['identifierTime']);
+                    return $column;
+                }, $r['configuration']['columns']);
                 $mapping = [
                     'source' => $r['id'],
                     'columns' => array_keys($r['configuration']['columns']),

--- a/tests/Keboola/ConfigMigrationTool/Migrations/KeboolaGoodDataWriterMigrationTest.php
+++ b/tests/Keboola/ConfigMigrationTool/Migrations/KeboolaGoodDataWriterMigrationTest.php
@@ -111,6 +111,7 @@ class KeboolaGoodDataWriterMigrationTest extends TestCase
                 'c4' => [
                     'type' => 'DATE',
                     'format' => 'yyyy-MM-dd HH:mm:ss',
+                    'identifierTime' => 'shouldBeSkipped',
                     'dateDimension' => 'd1',
                 ],
                 'c5' => [


### PR DESCRIPTION
fixes #78 
property `identifierTime` sa v starom writery nepouziva takze ani v novom. Tato uprava preskoci migraciu tejto property.
