### PR TITLE
Fix migration of project.backend

### DIFF
--- a/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoodDataWriterMigration.php
+++ b/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoodDataWriterMigration.php
@@ -149,6 +149,11 @@ class KeboolaGoodDataWriterMigration extends GenericCopyMigration
                 = $newConfig['configuration']['parameters']['domain']['url'];
         }
         unset($newConfig['configuration']['parameters']['domain']);
+        if (!empty($newConfig['configuration']['parameters']['project']['backend'])) {
+            $newConfig['configuration']['parameters']['project']['backendUrl']
+                = $newConfig['configuration']['parameters']['project']['backend'];
+            unset($newConfig['configuration']['parameters']['project']['backend']);
+        }
         if (isset($newConfig['configuration']['parameters']['user']['password'])) {
             $newConfig['configuration']['parameters']['user']['#password']
                 = $newConfig['configuration']['parameters']['user']['password'];


### PR DESCRIPTION
Tak ještě project.backend ze starýho Writeru (https://github.com/keboola/gooddata-writer/blob/e587c8160fdf49038d6b542f13a41f8e9417acf1/Configuration/ConfigurationStorage.php#L199) se musí přeložit na project.backendUrl novýho (https://github.com/keboola/gooddata-writer-v3/blob/e7c82278f723ca4c64670f55045c08d1e05282ad/src/ConfigDefinition.php#L32)