### PR TITLE
gooddata migration - fix migration of disabled tables

### DIFF
--- a/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoodDataWriterMigration.php
+++ b/src/Keboola/ConfigMigrationTool/Migration/KeboolaGoodDataWriterMigration.php
@@ -187,6 +187,7 @@ class KeboolaGoodDataWriterMigration extends GenericCopyMigration
                 }
                 if (empty($r['configuration']['export'])) {
                     $mapping['limit'] = 1;
+                    $r['configuration']['disabled'] = true;
                 }
                 $newConfig['configuration']['storage']['input']['tables'][] = $mapping;
 

--- a/tests/Keboola/ConfigMigrationTool/Migrations/KeboolaGoodDataWriterMigrationTest.php
+++ b/tests/Keboola/ConfigMigrationTool/Migrations/KeboolaGoodDataWriterMigrationTest.php
@@ -263,6 +263,7 @@ class KeboolaGoodDataWriterMigrationTest extends TestCase
 
         $this->assertEquals('t3', $result['configuration']['storage']['input']['tables'][2]['source']);
         $this->assertArrayHasKey('limit', $result['configuration']['storage']['input']['tables'][2]);
+        $this->assertEquals(true, $result['configuration']['parameters']['tables']['t3']['disabled']);
         $this->assertEquals(1, $result['configuration']['storage']['input']['tables'][2]['limit']);
         $this->assertArrayNotHasKey('changed_since', $result['configuration']['storage']['input']['tables'][2]);
     }


### PR DESCRIPTION
Tabulkam ktore maju v starom writery nastaveny export=0 sa pri migracii do noveho writeru nenstavuje `disabled:true`. Tato uprava pridava disabled:true pre zadisablovane tabulky:
viac infa&detailnejsi debug: https://keboola.slack.com/archives/C02CGRFK2/p1565716334003100
