### PR TITLE
Remove image parameter validation for old GD migrations

### DIFF
--- a/src/Keboola/ConfigMigrationTool/Application.php
+++ b/src/Keboola/ConfigMigrationTool/Application.php
@@ -36,8 +36,6 @@ class Application
 
     public function action(array $config) : array
     {
-        $this->validateImageParameters($config);
-
         $action = $config['action'];
         if ($action == 'supported-migrations') {
             return $this->getSupportedMigrations();

--- a/src/Keboola/ConfigMigrationTool/Application.php
+++ b/src/Keboola/ConfigMigrationTool/Application.php
@@ -28,28 +28,8 @@ class Application
         $this->logger = $logger;
     }
 
-    public function validateImageParameters(array $config) : void
-    {
-        $required = [
-            '#demo_token',
-            '#manage_token',
-            '#production_token',
-            'gooddata_provisioning_url',
-            'gooddata_url',
-            'gooddata_writer_url',
-            'project_access_domain',
-        ];
-        foreach ($required as $r) {
-            if (!isset($config['image_parameters'][$r])) {
-                throw new \Exception("Parameter $r is missing from image parameters");
-            }
-        }
-    }
-
     public function run(array $config) : void
     {
-        $this->validateImageParameters($config);
-
         $migration = $this->getMigration($config);
         $migration->execute();
     }


### PR DESCRIPTION
@JakubMatejka this stuff is deprecated right?  I mean there isn't even any AZ stack values in the component definition

https://keboola.zendesk.com/agent/tickets/19024